### PR TITLE
Resolve "IS_EMPTY define did not work on MSVC"

### DIFF
--- a/make/autoconf/jdk-version.m4
+++ b/make/autoconf/jdk-version.m4
@@ -466,6 +466,8 @@ AC_DEFUN_ONCE([JDKVER_SETUP_JDK_VERSION_NUMBERS],
   fi
   VERSION_STRING=$version_with_build${VERSION_OPT:+-$VERSION_OPT}
 
+  # TODO Reset VERSION_BUILD to 0 after computing the string if it was 0 before?
+
   # The short version string, just VERSION_NUMBER and PRE, if present.
   VERSION_SHORT=$VERSION_NUMBER${VERSION_PRE:+-$VERSION_PRE}
 

--- a/make/data/hotspot-symbols/symbols-unix
+++ b/make/data/hotspot-symbols/symbols-unix
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -158,6 +158,7 @@ JVM_IsSupportedJNIVersion
 JVM_IsThreadAlive
 JVM_IsVMGeneratedMethodIx
 JVM_LatestUserDefinedLoader
+JVM_LoadZipLibrary
 JVM_LoadLibrary
 JVM_LookupDefineClass
 JVM_LookupLambdaProxyClassFromArchive

--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -61,11 +61,6 @@ else
   OPENJDK_TARGET_CPU_VM_VERSION := $(OPENJDK_TARGET_CPU)
 endif
 
-ifeq ($(VERSION_BUILD), )
-  # Hotspot cannot handle an empty build number
-  VERSION_BUILD := 0
-endif
-
 CFLAGS_VM_VERSION := \
     $(VERSION_CFLAGS) \
     -DHOTSPOT_VERSION_STRING='"$(VERSION_STRING)"' \

--- a/src/hotspot/cpu/aarch64/immediate_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/immediate_aarch64.cpp
@@ -129,8 +129,17 @@ static inline uint32_t uimm(uint32_t val, int hi, int lo)
 
 uint64_t replicate(uint64_t bits, int nbits, int count)
 {
+  assert(count > 0, "must be");
+  assert(nbits > 0, "must be");
+  assert(count * nbits <= 64, "must be");
+
+  // Special case nbits == 64 since the shift below with that nbits value
+  // would result in undefined behavior.
+  if (nbits == 64) {
+    return bits;
+  }
+
   uint64_t result = 0;
-  // nbits may be 64 in which case we want mask to be -1
   uint64_t mask = ones(nbits);
   for (int i = 0; i < count ; i++) {
     result <<= nbits;

--- a/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2021 SAP SE. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -4656,8 +4656,6 @@ class StubGenerator: public StubCodeGenerator {
 
  public:
   StubGenerator(CodeBuffer* code, bool all) : StubCodeGenerator(code) {
-    // replace the standard masm with a special one:
-    _masm = new MacroAssembler(code);
     if (all) {
       generate_all();
     } else {

--- a/src/hotspot/cpu/s390/stubGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/stubGenerator_s390.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2016, 2019 SAP SE. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2404,9 +2404,6 @@ class StubGenerator: public StubCodeGenerator {
 
  public:
   StubGenerator(CodeBuffer* code, bool all) : StubCodeGenerator(code) {
-    // Replace the standard masm with a special one:
-    _masm = new MacroAssembler(code);
-
     _stub_count = !all ? 0x100 : 0x200;
     if (all) {
       generate_all();

--- a/src/hotspot/share/cds/lambdaFormInvokers.hpp
+++ b/src/hotspot/share/cds/lambdaFormInvokers.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,6 @@ class LambdaFormInvokers : public AllStatic {
   static void add_regenerated_class(oop regenerated_class);
  public:
   static void append(char* line);
-  static void append_filtered(char* line);
   static void dump_static_archive_invokers();
   static void read_static_archive_invokers();
   static void regenerate_holder_classes(TRAPS);

--- a/src/hotspot/share/classfile/classLoader.cpp
+++ b/src/hotspot/share/classfile/classLoader.cpp
@@ -99,7 +99,8 @@ static FindEntry_t       FindEntry          = NULL;
 static ReadEntry_t       ReadEntry          = NULL;
 static GetNextEntry_t    GetNextEntry       = NULL;
 static Crc32_t           Crc32              = NULL;
-int ClassLoader::_libzip_loaded = 0;
+int    ClassLoader::_libzip_loaded          = 0;
+void*  ClassLoader::_zip_handle             = NULL;
 
 // Entry points for jimage.dll for loading jimage file entries
 
@@ -942,20 +943,19 @@ void ClassLoader::load_zip_library() {
   assert(ZipOpen == NULL, "should not load zip library twice");
   char path[JVM_MAXPATHLEN];
   char ebuf[1024];
-  void* handle = NULL;
   if (os::dll_locate_lib(path, sizeof(path), Arguments::get_dll_dir(), "zip")) {
-    handle = os::dll_load(path, ebuf, sizeof ebuf);
+    _zip_handle = os::dll_load(path, ebuf, sizeof ebuf);
   }
-  if (handle == NULL) {
+  if (_zip_handle == NULL) {
     vm_exit_during_initialization("Unable to load zip library", path);
   }
 
-  ZipOpen = CAST_TO_FN_PTR(ZipOpen_t, dll_lookup(handle, "ZIP_Open", path));
-  ZipClose = CAST_TO_FN_PTR(ZipClose_t, dll_lookup(handle, "ZIP_Close", path));
-  FindEntry = CAST_TO_FN_PTR(FindEntry_t, dll_lookup(handle, "ZIP_FindEntry", path));
-  ReadEntry = CAST_TO_FN_PTR(ReadEntry_t, dll_lookup(handle, "ZIP_ReadEntry", path));
-  GetNextEntry = CAST_TO_FN_PTR(GetNextEntry_t, dll_lookup(handle, "ZIP_GetNextEntry", path));
-  Crc32 = CAST_TO_FN_PTR(Crc32_t, dll_lookup(handle, "ZIP_CRC32", path));
+  ZipOpen = CAST_TO_FN_PTR(ZipOpen_t, dll_lookup(_zip_handle, "ZIP_Open", path));
+  ZipClose = CAST_TO_FN_PTR(ZipClose_t, dll_lookup(_zip_handle, "ZIP_Close", path));
+  FindEntry = CAST_TO_FN_PTR(FindEntry_t, dll_lookup(_zip_handle, "ZIP_FindEntry", path));
+  ReadEntry = CAST_TO_FN_PTR(ReadEntry_t, dll_lookup(_zip_handle, "ZIP_ReadEntry", path));
+  GetNextEntry = CAST_TO_FN_PTR(GetNextEntry_t, dll_lookup(_zip_handle, "ZIP_GetNextEntry", path));
+  Crc32 = CAST_TO_FN_PTR(Crc32_t, dll_lookup(_zip_handle, "ZIP_CRC32", path));
 }
 
 void ClassLoader::load_jimage_library() {

--- a/src/hotspot/share/classfile/classLoader.hpp
+++ b/src/hotspot/share/classfile/classLoader.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -229,6 +229,9 @@ class ClassLoader: AllStatic {
                                            bool check_for_duplicates);
   CDS_ONLY(static void add_to_module_path_entries(const char* path,
                                            ClassPathEntry* entry);)
+
+  // cache the zip library handle
+  static void* _zip_handle;
  public:
   CDS_ONLY(static ClassPathEntry* app_classpath_entries() {return _app_classpath_entries;})
   CDS_ONLY(static ClassPathEntry* module_path_entries() {return _module_path_entries;})
@@ -253,9 +256,10 @@ class ClassLoader: AllStatic {
  private:
   static int  _libzip_loaded; // used to sync loading zip.
   static void release_load_zip_library();
-  static inline void load_zip_library_if_needed();
 
  public:
+  static inline void load_zip_library_if_needed();
+  static void* zip_library_handle() { return _zip_handle; }
   static jzfile* open_zip_file(const char* canonical_path, char** error_msg, JavaThread* thread);
   static ClassPathEntry* create_class_path_entry(JavaThread* current,
                                                  const char *path, const struct stat* st,

--- a/src/hotspot/share/classfile/systemDictionaryShared.cpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1415,6 +1415,11 @@ InstanceKlass* SystemDictionaryShared::find_builtin_class(Symbol* name) {
   if (record != NULL) {
     assert(!record->_klass->is_hidden(), "hidden class cannot be looked up by name");
     assert(check_alignment(record->_klass), "Address not aligned");
+    // We did not save the classfile data of the regenerated LambdaForm invoker classes,
+    // so we cannot support CLFH for such classes.
+    if (record->_klass->is_regenerated() && JvmtiExport::should_post_class_file_load_hook()) {
+       return NULL;
+    }
     return record->_klass;
   } else {
     return NULL;

--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -256,7 +256,7 @@ class nmethod : public CompiledMethod {
   // stack.  An not_entrant method can be removed when there are no
   // more activations, i.e., when the _stack_traversal_mark is less than
   // current sweep traversal index.
-  volatile long _stack_traversal_mark;
+  volatile int64_t _stack_traversal_mark;
 
   // The _hotness_counter indicates the hotness of a method. The higher
   // the value the hotter the method. The hotness counter of a nmethod is
@@ -538,8 +538,8 @@ public:
   void fix_oop_relocations()                           { fix_oop_relocations(NULL, NULL, false); }
 
   // Sweeper support
-  long  stack_traversal_mark()                    { return _stack_traversal_mark; }
-  void  set_stack_traversal_mark(long l)          { _stack_traversal_mark = l; }
+  int64_t stack_traversal_mark()                  { return _stack_traversal_mark; }
+  void    set_stack_traversal_mark(int64_t l)     { _stack_traversal_mark = l; }
 
   // On-stack replacement support
   int   osr_entry_bci() const                     { assert(is_osr_method(), "wrong kind of nmethod"); return _entry_bci; }

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -186,7 +186,7 @@ int CompileBroker::_sum_standard_bytes_compiled    = 0;
 int CompileBroker::_sum_nmethod_size               = 0;
 int CompileBroker::_sum_nmethod_code_size          = 0;
 
-long CompileBroker::_peak_compilation_time         = 0;
+jlong CompileBroker::_peak_compilation_time        = 0;
 
 CompilerStatistics CompileBroker::_stats_per_level[CompLevel_full_optimization];
 

--- a/src/hotspot/share/compiler/compileBroker.hpp
+++ b/src/hotspot/share/compiler/compileBroker.hpp
@@ -222,7 +222,7 @@ class CompileBroker: AllStatic {
   static int _sum_standard_bytes_compiled;
   static int _sum_nmethod_size;
   static int _sum_nmethod_code_size;
-  static long _peak_compilation_time;
+  static jlong _peak_compilation_time;
 
   static CompilerStatistics _stats_per_level[];
 
@@ -411,8 +411,8 @@ public:
   static int get_sum_standard_bytes_compiled() {    return _sum_standard_bytes_compiled; }
   static int get_sum_nmethod_size() {               return _sum_nmethod_size;}
   static int get_sum_nmethod_code_size() {          return _sum_nmethod_code_size; }
-  static long get_peak_compilation_time() {         return _peak_compilation_time; }
-  static long get_total_compilation_time() {        return _t_total_compilation.milliseconds(); }
+  static jlong get_peak_compilation_time() {        return _peak_compilation_time; }
+  static jlong get_total_compilation_time() {       return _t_total_compilation.milliseconds(); }
 
   // Log that compilation profiling is skipped because metaspace is full.
   static void log_metaspace_failure();

--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
@@ -87,7 +87,7 @@ void G1BlockOffsetTablePart::update() {
   while (next_addr < limit) {
     prev_addr = next_addr;
     next_addr  = prev_addr + block_size(prev_addr);
-    alloc_block(prev_addr, next_addr);
+    update_for_block(prev_addr, next_addr);
   }
   assert(next_addr == limit, "Should stop the scan at the limit.");
 }
@@ -212,8 +212,8 @@ void G1BlockOffsetTablePart::check_all_cards(size_t start_card, size_t end_card)
 //       ( ^    ]
 //         blk_start
 //
-void G1BlockOffsetTablePart::alloc_block_work(HeapWord* blk_start,
-                                              HeapWord* blk_end) {
+void G1BlockOffsetTablePart::update_for_block_work(HeapWord* blk_start,
+                                                   HeapWord* blk_end) {
   HeapWord* const cur_card_boundary = align_up_by_card_size(blk_start);
   size_t const index =  _bot->index_for_raw(cur_card_boundary);
 
@@ -335,8 +335,8 @@ void G1BlockOffsetTablePart::print_on(outputStream* out) {
 #endif // !PRODUCT
 
 void G1BlockOffsetTablePart::set_for_starts_humongous(HeapWord* obj_top, size_t fill_size) {
-  alloc_block(_hr->bottom(), obj_top);
+  update_for_block(_hr->bottom(), obj_top);
   if (fill_size > 0) {
-    alloc_block(obj_top, fill_size);
+    update_for_block(obj_top, fill_size);
   }
 }

--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
@@ -138,7 +138,7 @@ private:
                                                     const void* addr) const;
 
   // Update BOT entries corresponding to the mem range [blk_start, blk_end).
-  void alloc_block_work(HeapWord* blk_start, HeapWord* blk_end);
+  void update_for_block_work(HeapWord* blk_start, HeapWord* blk_end);
 
   void check_all_cards(size_t left_card, size_t right_card) const;
 
@@ -168,14 +168,14 @@ public:
   // in a space covered by the table.)
   inline HeapWord* block_start(const void* addr);
 
-  void alloc_block(HeapWord* blk_start, HeapWord* blk_end) {
+  void update_for_block(HeapWord* blk_start, HeapWord* blk_end) {
     if (is_crossing_card_boundary(blk_start, blk_end)) {
-      alloc_block_work(blk_start, blk_end);
+      update_for_block_work(blk_start, blk_end);
     }
   }
 
-  void alloc_block(HeapWord* blk_start, size_t size) {
-    alloc_block(blk_start, blk_start + size);
+  void update_for_block(HeapWord* blk_start, size_t size) {
+    update_for_block(blk_start, blk_start + size);
   }
 
   void set_for_starts_humongous(HeapWord* obj_top, size_t fill_size);

--- a/src/hotspot/share/gc/g1/g1EvacFailure.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacFailure.cpp
@@ -98,7 +98,7 @@ public:
 
     HeapWord* obj_end = obj_addr + obj_size;
     _last_forwarded_object_end = obj_end;
-    _hr->alloc_block_in_bot(obj_addr, obj_end);
+    _hr->update_bot_for_block(obj_addr, obj_end);
     return obj_size;
   }
 
@@ -116,13 +116,13 @@ public:
       CollectedHeap::fill_with_objects(start, gap_size);
 
       HeapWord* end_first_obj = start + cast_to_oop(start)->size();
-      _hr->alloc_block_in_bot(start, end_first_obj);
+      _hr->update_bot_for_block(start, end_first_obj);
       // Fill_with_objects() may have created multiple (i.e. two)
       // objects, as the max_fill_size() is half a region.
       // After updating the BOT for the first object, also update the
       // BOT for the second object to make the BOT complete.
       if (end_first_obj != end) {
-        _hr->alloc_block_in_bot(end_first_obj, end);
+        _hr->update_bot_for_block(end_first_obj, end);
 #ifdef ASSERT
         size_t size_second_obj = cast_to_oop(end_first_obj)->size();
         HeapWord* end_of_second_obj = end_first_obj + size_second_obj;

--- a/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.cpp
@@ -107,7 +107,7 @@ void G1FullGCCompactionPoint::forward(oop object, size_t size) {
 
   // Update compaction values.
   _compaction_top += size;
-  _current_region->alloc_block_in_bot(_compaction_top - size, _compaction_top);
+  _current_region->update_bot_for_block(_compaction_top - size, _compaction_top);
 }
 
 void G1FullGCCompactionPoint::add(HeapRegion* hr) {

--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -787,8 +787,8 @@ void HeapRegion::mangle_unused_area() {
 }
 #endif
 
-void HeapRegion::alloc_block_in_bot(HeapWord* start, HeapWord* end) {
-  _bot_part.alloc_block(start, end);
+void HeapRegion::update_bot_for_block(HeapWord* start, HeapWord* end) {
+  _bot_part.update_for_block(start, end);
 }
 
 void HeapRegion::object_iterate(ObjectClosure* blk) {

--- a/src/hotspot/share/gc/g1/heapRegion.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.hpp
@@ -167,7 +167,7 @@ public:
 
   // Full GC support methods.
 
-  void alloc_block_in_bot(HeapWord* start, HeapWord* end);
+  void update_bot_for_block(HeapWord* start, HeapWord* end);
 
   // Update heap region that has been compacted to be consistent after Full GC.
   void reset_compacted_after_full_gc();

--- a/src/hotspot/share/gc/g1/heapRegion.inline.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.inline.hpp
@@ -237,7 +237,7 @@ inline void HeapRegion::update_bot_for_obj(HeapWord* obj_start, size_t obj_size)
          HR_FORMAT_PARAMS(this),
          p2i(obj_start), p2i(obj_end));
 
-  _bot_part.alloc_block(obj_start, obj_end);
+  _bot_part.update_for_block(obj_start, obj_end);
 }
 
 inline void HeapRegion::note_start_of_marking() {

--- a/src/hotspot/share/include/jvm.h
+++ b/src/hotspot/share/include/jvm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -149,6 +149,9 @@ JVM_ActiveProcessorCount(void);
 
 JNIEXPORT jboolean JNICALL
 JVM_IsUseContainerSupport(void);
+
+JNIEXPORT void * JNICALL
+JVM_LoadZipLibrary();
 
 JNIEXPORT void * JNICALL
 JVM_LoadLibrary(const char *name, jboolean throwException);

--- a/src/hotspot/share/jvmci/jvmciEnv.cpp
+++ b/src/hotspot/share/jvmci/jvmciEnv.cpp
@@ -553,7 +553,7 @@ void JVMCIEnv::put_int_at(JVMCIPrimitiveArray array, int index, jint value) {
   }
 }
 
-long JVMCIEnv::get_long_at(JVMCIPrimitiveArray array, int index) {
+jlong JVMCIEnv::get_long_at(JVMCIPrimitiveArray array, int index) {
   if (is_hotspot()) {
     return HotSpotJVMCI::resolve(array)->long_at(index);
   } else {

--- a/src/hotspot/share/jvmci/jvmciEnv.hpp
+++ b/src/hotspot/share/jvmci/jvmciEnv.hpp
@@ -251,7 +251,7 @@ public:
   jint get_int_at(JVMCIPrimitiveArray array, int index);
   void put_int_at(JVMCIPrimitiveArray array, int index, jint value);
 
-  long get_long_at(JVMCIPrimitiveArray array, int index);
+  jlong get_long_at(JVMCIPrimitiveArray array, int index);
   void put_long_at(JVMCIPrimitiveArray array, int index, jlong value);
 
   void copy_bytes_to(JVMCIPrimitiveArray src, jbyte* dest, int offset, jsize length);

--- a/src/hotspot/share/oops/klass.hpp
+++ b/src/hotspot/share/oops/klass.hpp
@@ -175,7 +175,8 @@ private:
   enum {
     _archived_lambda_proxy_is_available = 2,
     _has_value_based_class_annotation = 4,
-    _verified_at_dump_time = 8
+    _verified_at_dump_time = 8,
+    _regenerated = 16
   };
 #endif
 
@@ -339,6 +340,13 @@ protected:
     NOT_CDS(return false;)
   }
 
+  void set_regenerated() {
+    CDS_ONLY(_shared_class_flags |= _regenerated;)
+  }
+  bool is_regenerated() const {
+    CDS_ONLY(return (_shared_class_flags & _regenerated) != 0;)
+    NOT_CDS(return false;)
+  }
 
   // Obtain the module or package for this class
   virtual ModuleEntry* module() const = 0;

--- a/src/hotspot/share/oops/klassVtable.cpp
+++ b/src/hotspot/share/oops/klassVtable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -274,7 +274,7 @@ void klassVtable::initialize_vtable(GrowableArray<InstanceKlass*>* supers) {
 }
 
 // Returns true iff super_method can be overridden by a method in targetclassname
-// See JLS 3rd edition 8.4.6.1
+// See JLS 8.4.8.1
 // Assumes name-signature match
 // Note that the InstanceKlass of the method in the targetclassname has not always been created yet
 static bool can_be_overridden(Method* super_method, Handle targetclassloader, Symbol* targetclassname) {

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -30,7 +30,7 @@
 #include "cds/heapShared.hpp"
 #include "cds/lambdaFormInvokers.hpp"
 #include "classfile/classFileStream.hpp"
-#include "classfile/classLoader.hpp"
+#include "classfile/classLoader.inline.hpp"
 #include "classfile/classLoaderData.hpp"
 #include "classfile/classLoaderData.inline.hpp"
 #include "classfile/classLoadInfo.hpp"
@@ -3372,6 +3372,11 @@ JVM_END
 
 
 // Library support ///////////////////////////////////////////////////////////////////////////
+
+JVM_LEAF(void*, JVM_LoadZipLibrary())
+  ClassLoader::load_zip_library_if_needed();
+  return ClassLoader::zip_library_handle();
+JVM_END
 
 JVM_ENTRY_NO_ENV(void*, JVM_LoadLibrary(const char* name, jboolean throwException))
   //%note jvm_ct

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -3689,9 +3689,9 @@ JVM_ENTRY(void, JVM_LogLambdaFormInvoker(JNIEnv *env, jstring line))
     Handle h_line (THREAD, JNIHandles::resolve_non_null(line));
     char* c_line = java_lang_String::as_utf8_string(h_line());
     if (DynamicDumpSharedSpaces) {
-      // Note: LambdaFormInvokers::append_filtered and LambdaFormInvokers::append take same format which is not
+      // Note: LambdaFormInvokers::append take same format which is not
       // same as below the print format. The line does not include LAMBDA_FORM_TAG.
-      LambdaFormInvokers::append_filtered(os::strdup((const char*)c_line, mtInternal));
+      LambdaFormInvokers::append(os::strdup((const char*)c_line, mtInternal));
     }
     if (ClassListWriter::is_enabled()) {
       ClassListWriter w;

--- a/src/hotspot/share/prims/jvmtiClassFileReconstituter.hpp
+++ b/src/hotspot/share/prims/jvmtiClassFileReconstituter.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -101,6 +101,7 @@ class JvmtiClassFileReconstituter : public JvmtiConstantPoolReconstituter {
   void write_method_info(const methodHandle& method);
   void write_code_attribute(const methodHandle& method);
   void write_exceptions_attribute(ConstMethod* const_method);
+  void write_method_parameter_attribute(const ConstMethod* const_method);
   void write_synthetic_attribute();
   void write_class_attributes();
   void write_source_file_attribute();

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2266,21 +2266,6 @@ void VM_RedefineClasses::rewrite_cp_refs_in_method(methodHandle method,
         break;
     }
   } // end for each bytecode
-
-  // We also need to rewrite the parameter name indexes, if there is
-  // method parameter data present
-  if(method->has_method_parameters()) {
-    const int len = method->method_parameters_length();
-    MethodParametersElement* elem = method->method_parameters_start();
-
-    for (int i = 0; i < len; i++) {
-      const u2 cp_index = elem[i].name_cp_index;
-      const u2 new_cp_index = find_new_index(cp_index);
-      if (new_cp_index != 0) {
-        elem[i].name_cp_index = new_cp_index;
-      }
-    }
-  }
 } // end rewrite_cp_refs_in_method()
 
 
@@ -3693,6 +3678,19 @@ void VM_RedefineClasses::set_new_constant_pool(
         }
       } // end for each local variable table entry
     } // end if there are local variable table entries
+
+    // Update constant pool indices in the method's method_parameters.
+    int mp_length = method->method_parameters_length();
+    if (mp_length > 0) {
+      MethodParametersElement* elem = method->method_parameters_start();
+      for (int j = 0; j < mp_length; j++) {
+        const int cp_index = elem[j].name_cp_index;
+        const int new_cp_index = find_new_index(cp_index);
+        if (new_cp_index != 0) {
+          elem[j].name_cp_index = (u2)new_cp_index;
+        }
+      }
+    }
 
     rewrite_cp_refs_in_stack_map_table(method);
   } // end for each method

--- a/src/hotspot/share/runtime/abstract_vm_version.cpp
+++ b/src/hotspot/share/runtime/abstract_vm_version.cpp
@@ -82,7 +82,12 @@ int Abstract_VM_Version::_vm_major_version = VERSION_FEATURE;
 int Abstract_VM_Version::_vm_minor_version = VERSION_INTERIM;
 int Abstract_VM_Version::_vm_security_version = VERSION_UPDATE;
 int Abstract_VM_Version::_vm_patch_version = VERSION_PATCH;
+#if ~(~VERSION_BUILD + 0) == 0 && ~(~VERSION_BUILD + 1) == 1 // Gotta be a neater way to do this...
+int Abstract_VM_Version::_vm_build_number = 0;
+#else
 int Abstract_VM_Version::_vm_build_number = VERSION_BUILD;
+// Do we want to do this for everything else besides VERSION_BUILD too?
+#endif
 
 #if defined(_LP64)
   #define VMLP "64-Bit "

--- a/src/hotspot/share/runtime/interfaceSupport.cpp
+++ b/src/hotspot/share/runtime/interfaceSupport.cpp
@@ -78,7 +78,7 @@ VMNativeEntryWrapper::~VMNativeEntryWrapper() {
 
 unsigned int InterfaceSupport::_scavenge_alot_counter = 1;
 unsigned int InterfaceSupport::_fullgc_alot_counter   = 1;
-int InterfaceSupport::_fullgc_alot_invocation = 0;
+intx InterfaceSupport::_fullgc_alot_invocation = 0;
 
 void InterfaceSupport::gc_alot() {
   Thread *thread = Thread::current();

--- a/src/hotspot/share/runtime/interfaceSupport.inline.hpp
+++ b/src/hotspot/share/runtime/interfaceSupport.inline.hpp
@@ -54,7 +54,7 @@ class InterfaceSupport: AllStatic {
  public:
   static unsigned int _scavenge_alot_counter;
   static unsigned int _fullgc_alot_counter;
-  static int _fullgc_alot_invocation;
+  static intx _fullgc_alot_invocation;
 
   // Helper methods used to implement +ScavengeALot and +FullGCALot
   static void check_gc_alot() { if (ScavengeALot || FullGCALot) gc_alot(); }

--- a/src/hotspot/share/runtime/stubCodeGenerator.cpp
+++ b/src/hotspot/share/runtime/stubCodeGenerator.cpp
@@ -69,7 +69,7 @@ void StubCodeDesc::print() const { print_on(tty); }
 // Implementation of StubCodeGenerator
 
 StubCodeGenerator::StubCodeGenerator(CodeBuffer* code, bool print_code) {
-  _masm = new MacroAssembler(code );
+  _masm = new MacroAssembler(code);
   _print_code = PrintStubCode || print_code;
 }
 

--- a/src/hotspot/share/runtime/sweeper.cpp
+++ b/src/hotspot/share/runtime/sweeper.cpp
@@ -55,9 +55,9 @@
 // Sweeper logging code
 class SweeperRecord {
  public:
-  int traversal;
+  int64_t traversal;
   int compile_id;
-  long traversal_mark;
+  int64_t traversal_mark;
   int state;
   const char* kind;
   address vep;
@@ -65,8 +65,8 @@ class SweeperRecord {
   int line;
 
   void print() {
-      tty->print_cr("traversal = %d compile_id = %d %s uep = " PTR_FORMAT " vep = "
-                    PTR_FORMAT " state = %d traversal_mark %ld line = %d",
+      tty->print_cr("traversal = " INT64_FORMAT " compile_id = %d %s uep = " PTR_FORMAT " vep = "
+                    PTR_FORMAT " state = %d traversal_mark " INT64_FORMAT " line = %d",
                     traversal,
                     compile_id,
                     kind == NULL ? "" : kind,
@@ -107,8 +107,8 @@ void NMethodSweeper::init_sweeper_log() {
 #endif
 
 CompiledMethodIterator NMethodSweeper::_current(CompiledMethodIterator::all_blobs); // Current compiled method
-long     NMethodSweeper::_traversals                   = 0;    // Stack scan count, also sweep ID.
-long     NMethodSweeper::_total_nof_code_cache_sweeps  = 0;    // Total number of full sweeps of the code cache
+int64_t  NMethodSweeper::_traversals                   = 0;    // Stack scan count, also sweep ID.
+int64_t  NMethodSweeper::_total_nof_code_cache_sweeps  = 0;    // Total number of full sweeps of the code cache
 int      NMethodSweeper::_seen                         = 0;    // Nof. nmethod we have currently processed in current pass of CodeCache
 size_t   NMethodSweeper::_sweep_threshold_bytes        = 0;    // Threshold for when to sweep. Updated after ergonomics
 
@@ -119,8 +119,8 @@ volatile size_t NMethodSweeper::_bytes_changed         = 0;    // Counts the tot
                                                                //   2) not_entrant -> zombie
 int    NMethodSweeper::_hotness_counter_reset_val       = 0;
 
-long   NMethodSweeper::_total_nof_methods_reclaimed     = 0;   // Accumulated nof methods flushed
-long   NMethodSweeper::_total_nof_c2_methods_reclaimed  = 0;   // Accumulated nof methods flushed
+int64_t NMethodSweeper::_total_nof_methods_reclaimed    = 0;   // Accumulated nof methods flushed
+int64_t NMethodSweeper::_total_nof_c2_methods_reclaimed = 0;   // Accumulated nof methods flushed
 size_t NMethodSweeper::_total_flushed_size              = 0;   // Total number of bytes flushed from the code cache
 Tickspan NMethodSweeper::_total_time_sweeping;                 // Accumulated time sweeping
 Tickspan NMethodSweeper::_total_time_this_sweep;               // Total time this sweep
@@ -187,7 +187,7 @@ CodeBlobClosure* NMethodSweeper::prepare_mark_active_nmethods() {
   _total_time_this_sweep = Tickspan();
 
   if (PrintMethodFlushing) {
-    tty->print_cr("### Sweep: stack traversal %ld", _traversals);
+    tty->print_cr("### Sweep: stack traversal " INT64_FORMAT, _traversals);
   }
   return &mark_activation_closure;
 }
@@ -217,7 +217,7 @@ void NMethodSweeper::sweeper_loop() {
     {
       ThreadBlockInVM tbivm(JavaThread::current());
       MonitorLocker waiter(CodeSweeper_lock, Mutex::_no_safepoint_check_flag);
-      const long wait_time = 60*60*24 * 1000;
+      const int64_t wait_time = 60*60*24 * 1000;
       timeout = waiter.wait(wait_time);
     }
     if (!timeout && (_should_sweep || _force_sweep)) {
@@ -646,7 +646,7 @@ void NMethodSweeper::log_sweep(const char* msg, const char* format, ...) {
     CodeCache::log_state(&s);
 
     ttyLocker ttyl;
-    xtty->begin_elem("sweeper state='%s' traversals='" INTX_FORMAT "' ", msg, (intx)traversal_count());
+    xtty->begin_elem("sweeper state='%s' traversals='" INT64_FORMAT "' ", msg, traversal_count());
     if (format != NULL) {
       va_list ap;
       va_start(ap, format);
@@ -664,8 +664,9 @@ void NMethodSweeper::print(outputStream* out) {
   out = (out == NULL) ? tty : out;
   out->print_cr("Code cache sweeper statistics:");
   out->print_cr("  Total sweep time:                %1.0lf ms", (double)_total_time_sweeping.value()/1000000);
-  out->print_cr("  Total number of full sweeps:     %ld", _total_nof_code_cache_sweeps);
-  out->print_cr("  Total number of flushed methods: %ld (thereof %ld C2 methods)", _total_nof_methods_reclaimed,
+  out->print_cr("  Total number of full sweeps:     " INT64_FORMAT, _total_nof_code_cache_sweeps);
+  out->print_cr("  Total number of flushed methods: " INT64_FORMAT " (thereof " INT64_FORMAT " C2 methods)",
+                                                    _total_nof_methods_reclaimed,
                                                     _total_nof_c2_methods_reclaimed);
   out->print_cr("  Total size of flushed methods:   " SIZE_FORMAT " kB", _total_flushed_size/K);
 }

--- a/src/hotspot/share/runtime/sweeper.hpp
+++ b/src/hotspot/share/runtime/sweeper.hpp
@@ -66,8 +66,8 @@ class NMethodSweeper : public AllStatic {
     MadeZombie,
     Flushed
   };
-  static long      _traversals;                   // Stack scan count, also sweep ID.
-  static long      _total_nof_code_cache_sweeps;  // Total number of full sweeps of the code cache
+  static int64_t   _traversals;                   // Stack scan count, also sweep ID.
+  static int64_t   _total_nof_code_cache_sweeps;  // Total number of full sweeps of the code cache
   static CompiledMethodIterator _current;         // Current compiled method
   static int       _seen;                         // Nof. nmethod we have currently processed in current pass of CodeCache
   static size_t    _sweep_threshold_bytes;        // The threshold for when to invoke sweeps
@@ -78,8 +78,8 @@ class NMethodSweeper : public AllStatic {
                                                   //   1) alive       -> not_entrant
                                                   //   2) not_entrant -> zombie
   // Stat counters
-  static long      _total_nof_methods_reclaimed;    // Accumulated nof methods flushed
-  static long      _total_nof_c2_methods_reclaimed; // Accumulated nof C2-compiled methods flushed
+  static int64_t   _total_nof_methods_reclaimed;    // Accumulated nof methods flushed
+  static int64_t   _total_nof_c2_methods_reclaimed; // Accumulated nof C2-compiled methods flushed
   static size_t    _total_flushed_size;             // Total size of flushed methods
   static int       _hotness_counter_reset_val;
 
@@ -97,10 +97,10 @@ class NMethodSweeper : public AllStatic {
   static void do_stack_scanning();
   static void sweep();
  public:
-  static long traversal_count()                    { return _traversals; }
+  static int64_t traversal_count()                 { return _traversals; }
   static size_t sweep_threshold_bytes()              { return _sweep_threshold_bytes; }
   static void set_sweep_threshold_bytes(size_t threshold) { _sweep_threshold_bytes = threshold; }
-  static int  total_nof_methods_reclaimed()        { return _total_nof_methods_reclaimed; }
+  static int64_t total_nof_methods_reclaimed()     { return _total_nof_methods_reclaimed; }
   static const Tickspan total_time_sweeping()      { return _total_time_sweeping; }
   static const Tickspan peak_sweep_time()          { return _peak_sweep_time; }
   static const Tickspan peak_sweep_fraction_time() { return _peak_sweep_fraction_time; }

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -660,7 +660,7 @@
   nonstatic_field(nmethod,                     _verified_entry_point,                         address)                               \
   nonstatic_field(nmethod,                     _osr_entry_point,                              address)                               \
   volatile_nonstatic_field(nmethod,            _lock_count,                                   jint)                                  \
-  volatile_nonstatic_field(nmethod,            _stack_traversal_mark,                         long)                                  \
+  volatile_nonstatic_field(nmethod,            _stack_traversal_mark,                         int64_t)                               \
   nonstatic_field(nmethod,                     _compile_id,                                   int)                                   \
   nonstatic_field(nmethod,                     _comp_level,                                   int)                                   \
                                                                                                                                      \
@@ -1199,6 +1199,7 @@
   declare_integer_type(ssize_t)                                           \
   declare_integer_type(intx)                                              \
   declare_integer_type(intptr_t)                                          \
+  declare_integer_type(int64_t)                                           \
   declare_unsigned_integer_type(uintx)                                    \
   declare_unsigned_integer_type(uintptr_t)                                \
   declare_unsigned_integer_type(uint8_t)                                  \

--- a/src/hotspot/share/services/mallocTracker.hpp
+++ b/src/hotspot/share/services/mallocTracker.hpp
@@ -31,6 +31,8 @@
 #include "services/nmtCommon.hpp"
 #include "utilities/nativeCallStack.hpp"
 
+class outputStream;
+
 /*
  * This counter class counts memory allocation and deallocation,
  * records total memory allocation size and number of allocations.
@@ -438,6 +440,14 @@ class MallocTracker : AllStatic {
   static inline void record_arena_size_change(ssize_t size, MEMFLAGS flags) {
     MallocMemorySummary::record_arena_size_change(size, flags);
   }
+
+  // Given a pointer, if it seems to point to the start of a valid malloced block,
+  // print the block. Note that since there is very low risk of memory looking
+  // accidentally like a valid malloc block header (canaries and all) this is not
+  // totally failproof. Only use this during debugging or when you can afford
+  // signals popping up, e.g. when writing an hs_err file.
+  static bool print_pointer_information(const void* p, outputStream* st);
+
  private:
   static inline MallocHeader* malloc_header(void *memblock) {
     assert(memblock != NULL, "NULL pointer");

--- a/src/hotspot/share/services/virtualMemoryTracker.hpp
+++ b/src/hotspot/share/services/virtualMemoryTracker.hpp
@@ -385,7 +385,9 @@ class VirtualMemoryTracker : AllStatic {
   // Walk virtual memory data structure for creating baseline, etc.
   static bool walk_virtual_memory(VirtualMemoryWalker* walker);
 
-  static const bool snapshot_region_contains(void* p, ReservedMemoryRegion& region);
+  // If p is contained within a known memory region, print information about it to the
+  // given stream and return true; false otherwise.
+  static bool print_containing_region(const void* p, outputStream* st);
 
   // Snapshot current thread stacks
   static void snapshot_thread_stacks();

--- a/src/java.base/share/classes/java/nio/channels/Selector.java
+++ b/src/java.base/share/classes/java/nio/channels/Selector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -355,7 +355,8 @@ public abstract class Selector implements Closeable {
      * of the {@link #wakeup wakeup} method.  </p>
      *
      * @return  The number of keys, possibly zero, whose ready-operation sets
-     *          were updated by the selection operation
+     *          now indicate readiness for at least one category of operations
+     *          for which the channel was not previously detected to be ready
      *
      * @throws  IOException
      *          If an I/O error occurs
@@ -383,8 +384,9 @@ public abstract class Selector implements Closeable {
      *                  channel to become ready; if zero, block indefinitely;
      *                  must not be negative
      *
-     * @return  The number of keys, possibly zero,
-     *          whose ready-operation sets were updated
+     * @return  The number of keys, possibly zero, whose ready-operation sets
+     *          now indicate readiness for at least one category of operations
+     *          for which the channel was not previously detected to be ready
      *
      * @throws  IOException
      *          If an I/O error occurs
@@ -406,8 +408,9 @@ public abstract class Selector implements Closeable {
      * this selector's {@link #wakeup wakeup} method is invoked, or the current
      * thread is interrupted, whichever comes first.  </p>
      *
-     * @return  The number of keys, possibly zero,
-     *          whose ready-operation sets were updated
+     * @return  The number of keys, possibly zero, whose ready-operation sets
+     *          now indicate readiness for at least one category of operations
+     *          for which the channel was not previously detected to be ready
      *
      * @throws  IOException
      *          If an I/O error occurs

--- a/src/java.base/share/classes/java/security/Provider.java
+++ b/src/java.base/share/classes/java/security/Provider.java
@@ -1116,11 +1116,6 @@ public abstract class Provider extends Properties {
         return new String[] {type, alg};
     }
 
-    // utility method for getting a String with service type and algorithm
-    private static String getKey(Service s) {
-        return s.getType() + "." + s.getAlgorithm();
-    }
-
     private static final String ALIAS_PREFIX = "Alg.Alias.";
     private static final String ALIAS_PREFIX_LOWER = "alg.alias.";
     private static final int ALIAS_LENGTH = ALIAS_PREFIX.length();
@@ -1544,20 +1539,11 @@ public abstract class Provider extends Properties {
         final String name;
         final boolean supportsParameter;
         final String constructorParameterClassName;
-        private volatile Class<?> constructorParameterClass;
 
         EngineDescription(String name, boolean sp, String paramName) {
             this.name = name;
             this.supportsParameter = sp;
             this.constructorParameterClassName = paramName;
-        }
-        Class<?> getConstructorParameterClass() throws ClassNotFoundException {
-            Class<?> clazz = constructorParameterClass;
-            if (clazz == null) {
-                clazz = Class.forName(constructorParameterClassName);
-                constructorParameterClass = clazz;
-            }
-            return clazz;
         }
     }
 

--- a/src/java.base/share/native/libjimage/imageDecompressor.cpp
+++ b/src/java.base/share/native/libjimage/imageDecompressor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,6 +30,7 @@
  */
 
 #include "jni.h"
+#include "jvm.h"
 #include "imageDecompressor.hpp"
 #include "endian.hpp"
 #ifdef WIN32
@@ -57,24 +58,14 @@ static ZipInflateFully_t ZipInflateFully        = NULL;
  * @return the address of the entry point or NULL
  */
 static void* findEntry(const char* name) {
-    void *addr = NULL;
-#ifdef WIN32
-    HMODULE handle = GetModuleHandle("zip.dll");
-    if (handle == NULL) {
-      handle = LoadLibrary("zip.dll");
-    }
-    if (handle == NULL) {
-      return NULL;
-    }
-    addr = (void*) GetProcAddress(handle, name);
-    return addr;
-#else
-    addr = dlopen(JNI_LIB_PREFIX "zip" JNI_LIB_SUFFIX, RTLD_GLOBAL|RTLD_LAZY);
+    void *addr = JVM_LoadZipLibrary();
     if (addr == NULL) {
         return NULL;
     }
-    addr = dlsym(addr, name);
-    return addr;
+#ifdef WIN32
+    return (void*) GetProcAddress(static_cast<HMODULE>(addr), name);
+#else
+    return dlsym(addr, name);
 #endif
 }
 

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/LdapClientFactory.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/LdapClientFactory.java
@@ -65,7 +65,23 @@ final class LdapClientFactory implements PooledConnectionFactory {
                 connTimeout, readTimeout, trace, pcb);
     }
 
+    public PooledConnection createPooledConnection(PoolCallback pcb, long timeout)
+        throws NamingException {
+        return new LdapClient(host, port, socketFactory,
+                guardedIntegerCast(timeout),
+                readTimeout, trace, pcb);
+    }
+
     public String toString() {
         return host + ":" + port;
+    }
+
+    private int guardedIntegerCast(long timeout) {
+        if (timeout < Integer.MIN_VALUE) {
+            return Integer.MIN_VALUE;
+        } else if (timeout > Integer.MAX_VALUE) {
+            return Integer.MAX_VALUE;
+        }
+        return (int) timeout;
     }
 }

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/pool/Pool.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/pool/Pool.java
@@ -31,10 +31,13 @@ import java.util.WeakHashMap;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 
 import java.io.PrintStream;
 import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
+import javax.naming.CommunicationException;
 import javax.naming.NamingException;
 
 /**
@@ -117,44 +120,108 @@ public final class Pool {
     public PooledConnection getPooledConnection(Object id, long timeout,
         PooledConnectionFactory factory) throws NamingException {
 
+        final long start = System.nanoTime();
+        long remaining = timeout;
+
         d("get(): ", id);
         if (debug) {
             synchronized (map) {
                 d("size: ", map.size());
             }
+            remaining = checkRemaining(start, remaining);
         }
 
         expungeStaleConnections();
 
-        Connections conns;
-        synchronized (map) {
-            conns = getConnections(id);
-            if (conns == null) {
-                d("get(): creating new connections list for ", id);
+        Connections conns = getOrCreateConnections(factory, id);
+        d("get(): size after: ", map.size());
+        remaining = checkRemaining(start, remaining);
 
-                // No connections for this id so create a new list
-                conns = new Connections(id, initSize, prefSize, maxSize,
-                    factory);
-                ConnectionsRef connsRef = new ConnectionsRef(conns);
-                map.put(id, connsRef);
-
-                // Create a weak reference to ConnectionsRef
-                Reference<ConnectionsRef> weakRef =
-                        new ConnectionsWeakRef(connsRef, queue);
-
-                // Keep the weak reference through the element of a linked list
-                weakRefs.add(weakRef);
-            }
-            d("get(): size after: ", map.size());
+        if (!conns.grabLock(remaining)) {
+            throw new CommunicationException("Timed out waiting for lock");
         }
 
-        return conns.get(timeout, factory); // get one connection from list
+        try {
+            remaining = checkRemaining(start, remaining);
+            PooledConnection conn = null;
+            while (remaining > 0 && conn == null) {
+                conn = getOrCreatePooledConnection(factory, conns, start, remaining);
+                // don't loop if the timeout has expired
+                remaining = checkRemaining(start, timeout);
+            }
+            return conn;
+        } finally {
+            conns.unlock();
+        }
     }
 
-    private Connections getConnections(Object id) {
-        ConnectionsRef ref = map.get(id);
-        return (ref != null) ? ref.getConnections() : null;
+    private Connections getOrCreateConnections(PooledConnectionFactory factory, Object id)
+            throws NamingException {
+
+        Connections conns;
+        synchronized (map) {
+            ConnectionsRef ref = map.get(id);
+            if (ref != null) {
+                return ref.getConnections();
+            }
+
+            d("get(): creating new connections list for ", id);
+
+            // No connections for this id so create a new list
+            conns = new Connections(id, initSize, prefSize, maxSize,
+                    factory, new ReentrantLock());
+
+            ConnectionsRef connsRef = new ConnectionsRef(conns);
+            map.put(id, connsRef);
+
+            // Create a weak reference to ConnectionsRef
+            Reference<ConnectionsRef> weakRef = new ConnectionsWeakRef(connsRef, queue);
+
+            // Keep the weak reference through the element of a linked list
+            weakRefs.add(weakRef);
+        }
+        return conns;
     }
+
+    private PooledConnection getOrCreatePooledConnection(
+            PooledConnectionFactory factory, Connections conns, long start, long timeout)
+            throws NamingException {
+        PooledConnection conn = conns.getAvailableConnection(timeout);
+        if (conn != null) {
+            return conn;
+        }
+        // no available cached connection
+        // check if list size already at maxSize before creating a new one
+        conn = conns.createConnection(factory, timeout);
+        if (conn != null) {
+            return conn;
+        }
+        // max number of connections already created,
+        // try waiting around for one to become available
+        if (timeout <= 0) {
+            conns.waitForAvailableConnection();
+        } else {
+            long remaining = checkRemaining(start, timeout);
+            conns.waitForAvailableConnection(remaining);
+        }
+        return null;
+    }
+
+    // Check whether we timed out
+    private long checkRemaining(long start, long timeout) throws CommunicationException {
+        if (timeout > 0) {
+            long current = System.nanoTime();
+            long remaining = timeout - TimeUnit.NANOSECONDS.toMillis(current - start);
+            if (remaining <= 0) {
+                throw new CommunicationException(
+                        "Timeout exceeded while waiting for a connection: " +
+                                timeout + "ms");
+            }
+            return remaining;
+        }
+        return Long.MAX_VALUE;
+    }
+
 
     /**
      * Goes through the connections in this Pool and expires ones that

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/pool/PooledConnectionFactory.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/pool/PooledConnectionFactory.java
@@ -44,4 +44,13 @@ public interface PooledConnectionFactory {
      */
     public abstract PooledConnection createPooledConnection(PoolCallback pcb)
         throws NamingException;
+
+    /**
+     * Creates a pooled connection.
+     * @param pcb callback responsible for removing and releasing the pooled
+     * connection from the pool.
+     * @param timeout the connection timeout
+     */
+    public abstract PooledConnection createPooledConnection(PoolCallback pcb, long timeout)
+        throws NamingException;
 };

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -667,7 +667,7 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
      *  It is assumed that both symbols have the same name.  The static
      *  modifier is ignored for this test.
      *
-     *  See JLS 8.4.6.1 (without transitivity) and 8.4.6.4
+     *  See JLS 8.4.8.1 (without transitivity) and 8.4.8.4
      */
     public boolean overrides(Symbol _other, TypeSymbol origin, Types types, boolean checkResult) {
         return false;
@@ -2060,7 +2060,7 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
          *  origin) don't get rejected as summarily and are put to test against the
          *  suitable criteria.
          *
-         *  See JLS 8.4.6.1 (without transitivity) and 8.4.6.4
+         *  See JLS 8.4.8.1 (without transitivity) and 8.4.8.4
          */
         public boolean overrides(Symbol _other, TypeSymbol origin, Types types, boolean checkResult) {
             return overrides(_other, origin, types, checkResult, true);
@@ -2077,7 +2077,7 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
          *  It is assumed that both symbols have the same name.  The static
          *  modifier is ignored for this test.
          *
-         *  See JLS 8.4.6.1 (without transitivity) and 8.4.6.4
+         *  See JLS 8.4.8.1 (without transitivity) and 8.4.8.4
          */
         public boolean overrides(Symbol _other, TypeSymbol origin, Types types, boolean checkResult,
                                             boolean requireConcreteIfInherited) {
@@ -2115,7 +2115,7 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
         }
 
         private boolean isOverridableIn(TypeSymbol origin) {
-            // JLS 8.4.6.1
+            // JLS 8.4.8.1
             switch ((int)(flags_field & Flags.AccessFlags)) {
             case Flags.PRIVATE:
                 return false;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -5470,7 +5470,7 @@ public class Attr extends JCTree.Visitor {
         } else {
             // Check that all extended classes and interfaces
             // are compatible (i.e. no two define methods with same arguments
-            // yet different return types).  (JLS 8.4.6.3)
+            // yet different return types).  (JLS 8.4.8.3)
             chk.checkCompatibleSupertypes(tree.pos(), c.type);
             if (allowDefaultMethods) {
                 chk.checkDefaultMethodClashes(tree.pos(), c.type);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1790,7 +1790,7 @@ public class Check {
             return;
         }
 
-        // Error if static method overrides instance method (JLS 8.4.6.2).
+        // Error if static method overrides instance method (JLS 8.4.8.2).
         if ((m.flags() & STATIC) != 0 &&
                    (other.flags() & STATIC) == 0) {
             log.error(TreeInfo.diagnosticPositionFor(m, tree),
@@ -1800,7 +1800,7 @@ public class Check {
         }
 
         // Error if instance method overrides static or final
-        // method (JLS 8.4.6.1).
+        // method (JLS 8.4.8.1).
         if ((other.flags() & FINAL) != 0 ||
                  (m.flags() & STATIC) == 0 &&
                  (other.flags() & STATIC) != 0) {
@@ -1816,7 +1816,7 @@ public class Check {
             return;
         }
 
-        // Error if overriding method has weaker access (JLS 8.4.6.3).
+        // Error if overriding method has weaker access (JLS 8.4.8.3).
         if (protection(m.flags()) > protection(other.flags())) {
             log.error(TreeInfo.diagnosticPositionFor(m, tree),
                       (other.flags() & AccessFlags) == 0 ?

--- a/src/jdk.jdi/share/classes/com/sun/jdi/ReferenceType.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/ReferenceType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -413,13 +413,13 @@ public interface ReferenceType
     /**
      * Returns a list containing each {@link Method}
      * declared or inherited by this type. Methods from superclasses
-     * or superinterfaces that that have been hidden or overridden
+     * or superinterfaces that have been hidden or overridden
      * are not included.
      * <p>
      * Note that despite this exclusion, multiple inherited methods
      * with the same signature can be present in the returned list, but
      * at most one can be a member of a {@link ClassType}.
-     * See JLS section 8.4.6 for details.
+     * See JLS section 8.4.8 for details.
      * <p>
      * For arrays ({@link ArrayType}) and primitive classes, the returned
      * list is always empty.
@@ -454,7 +454,7 @@ public interface ReferenceType
      * find overloaded methods.
      * <p>
      * Overridden and hidden methods are not included.
-     * See JLS (8.4.6) for details.
+     * See JLS (8.4.8) for details.
      * <p>
      * For arrays ({@link ArrayType}) and primitive classes, the returned
      * list is always empty.
@@ -478,7 +478,7 @@ public interface ReferenceType
      * <li><code>(IIII)Z</code>
      * </ul>
      * This method follows the inheritance rules specified
-     * in the JLS (8.4.6) to determine visibility.
+     * in the JLS (8.4.8) to determine visibility.
      * <p>
      * At most one method in the list is a concrete method and a
      * component of {@link ClassType}; any other methods in the list

--- a/src/jdk.jstatd/share/man/jstatd.1
+++ b/src/jdk.jstatd/share/man/jstatd.1
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
+.\" Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
 .\" DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 .\"
 .\" This code is free software; you can redistribute it and/or modify it
@@ -120,15 +120,12 @@ local security policies should be considered before you start the
 \f[CB]jstatd\f[R] process, particularly in production environments or on
 networks that aren\[aq]t secure.
 .PP
-The \f[CB]jstatd\f[R] server installs an instance of
-\f[CB]RMISecurityPolicy\f[R] when no other security manager is installed,
-and therefore, requires a security policy file to be specified.
-The policy file must conform to Default Policy Implementation and Policy
-File Syntax.
+For security purposes, the \f[CB]jstatd\f[R] server uses an RMI
+ObjectInputFilter to allow only essential classes to be deserialized.
 .PP
-If your security concerns can\[aq]t be addressed with a customized
-policy file, then the safest action is to not run the \f[CB]jstatd\f[R]
-server and use the \f[CB]jstat\f[R] and \f[CB]jps\f[R] tools locally.
+If your security concerns can\[aq]t be addressed, then the safest action
+is to not run the \f[CB]jstatd\f[R] server and use the \f[CB]jstat\f[R] and
+\f[CB]jps\f[R] tools locally.
 However, when using \f[CB]jps\f[R] to get a list of instrumented JVMs, the
 list will not include any JVMs running in docker containers.
 .SH REMOTE INTERFACE
@@ -149,7 +146,7 @@ This example assumes that no other server is bound to the default RMI
 registry port (port \f[CB]1099\f[R]).
 .RS
 .PP
-\f[CB]jstatd\ \-J\-Djava.security.policy=all.policy\f[R]
+\f[CB]jstatd\f[R]
 .RE
 .SH EXTERNAL RMI REGISTRY
 .PP
@@ -159,7 +156,7 @@ registry.
 .nf
 \f[CB]
 rmiregistry&
-jstatd\ \-J\-Djava.security.policy=all.policy
+jstatd
 \f[R]
 .fi
 .PP
@@ -169,7 +166,7 @@ registry server on port \f[CB]2020\f[R].
 .nf
 \f[CB]
 jrmiregistry\ 2020&
-jstatd\ \-J\-Djava.security.policy=all.policy\ \-p\ 2020
+jstatd\ \-p\ 2020
 \f[R]
 .fi
 .PP
@@ -180,7 +177,7 @@ registry server on port \f[CB]2020\f[R] and JMX connector bound to port
 .nf
 \f[CB]
 jrmiregistry\ 2020&
-jstatd\ \-J\-Djava.security.policy=all.policy\ \-p\ 2020\ \-r\ 2021
+jstatd\ \-p\ 2020\ \-r\ 2021
 \f[R]
 .fi
 .PP
@@ -191,7 +188,7 @@ registry on port 2020 that\[aq]s bound to
 .nf
 \f[CB]
 rmiregistry\ 2020&
-jstatd\ \-J\-Djava.security.policy=all.policy\ \-p\ 2020\ \-n\ AlternateJstatdServerName
+jstatd\ \-p\ 2020\ \-n\ AlternateJstatdServerName
 \f[R]
 .fi
 .SH STOP THE CREATION OF AN IN\-PROCESS RMI REGISTRY
@@ -203,7 +200,7 @@ If an RMI registry isn\[aq]t running, then an error message is
 displayed.
 .RS
 .PP
-\f[CB]jstatd\ \-J\-Djava.security.policy=all.policy\ \-nr\f[R]
+\f[CB]jstatd\ \-nr\f[R]
 .RE
 .SH ENABLE RMI LOGGING
 .PP
@@ -213,5 +210,5 @@ This technique is useful as a troubleshooting aid or for monitoring
 server activities.
 .RS
 .PP
-\f[CB]jstatd\ \-J\-Djava.security.policy=all.policy\ \-J\-Djava.rmi.server.logCalls=true\f[R]
+\f[CB]jstatd\ \-J\-Djava.rmi.server.logCalls=true\f[R]
 .RE

--- a/test/hotspot/jtreg/compiler/interpreter/Custom.jasm
+++ b/test/hotspot/jtreg/compiler/interpreter/Custom.jasm
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler/interpreter;
+
+/* JASM simplified from the following Java pattern:
+ *
+ * public class Custom {
+ *
+ *  static void test(int v) {
+ *      int i8 = 1;
+ *      try {
+ *          v += 1;
+ *      } catch (ArithmeticException exc1) {
+ *      } finally {
+ *          for (; i8 < 100; i8++) {
+ *          }
+ *      }
+ *  }
+ *
+ */
+
+super public class Custom {
+
+    public static Method test:"(I)V" stack 2 locals 3 {
+        iconst_1;
+        istore_1;
+    try t0;
+        iinc          0, 1;
+    endtry t0;
+Loop:
+        iload_1;
+        bipush        100;
+        if_icmpge     Lexit;
+        iinc          1, 1;
+        goto          Loop;                 // deoptimize here on backwards branch
+    catch t0 java/lang/ArithmeticException; // unreachable block
+        astore_2;
+Lexit:
+        return
+    }
+
+}

--- a/test/hotspot/jtreg/compiler/interpreter/VerifyStackWithUnreachableBlock.java
+++ b/test/hotspot/jtreg/compiler/interpreter/VerifyStackWithUnreachableBlock.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test VerifyStackWithUnreachableBlock
+ * @bug 8271055
+ * @compile Custom.jasm VerifyStackWithUnreachableBlock.java
+ * @summary Using VerifyStack for method that contains unreachable basic blocks
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+VerifyStack compiler.interpreter.VerifyStackWithUnreachableBlock
+ */
+
+package compiler.interpreter;
+
+public class VerifyStackWithUnreachableBlock {
+    public static void main(String[] strArr) {
+        for (int i = 0; i < 10000; i++) {
+            Custom.test(i);
+        }
+    }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/CDSLambdaInvoker.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/CDSLambdaInvoker.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+public class CDSLambdaInvoker {
+    public static void main(String args[]) throws Throwable {
+        invoke(MethodHandles.identity(double.class), 1.0);
+        invoke(MethodHandles.identity(long.class), 1);
+        invoke(MethodHandles.identity(int.class), 1);
+        invoke(MethodHandles.identity(float.class), 1.0f);
+
+        MethodHandles.Lookup lookup = MethodHandles.lookup();
+        MethodType mt = MethodType.methodType(void.class, float.class, double.class, int.class,
+                                              boolean.class, Object.class, long.class, double.class);
+        MethodHandle mh = lookup.findStatic(CDSLambdaInvoker.class, "callme", mt);
+        mh.invokeExact(4.0f, 5.0, 6, true, (Object)args, 7L, 8.0);
+    }
+
+    private static Object invoke(MethodHandle mh, Object ... args) throws Throwable {
+        try {
+            for (Object o : args) {
+                mh = MethodHandles.insertArguments(mh, 0, o);
+            }
+            return mh.invoke();
+        } catch (Throwable t) {
+            System.out.println("Failed to find, link and/or invoke " + mh.toString() + ": " + t.getMessage());
+            throw t;
+        }
+    }
+
+    private static void callme(float f, double d, int i, boolean b, Object o, long l, double d2) {
+
+    }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/TestLambdaInvokers.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/TestLambdaInvokers.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @key randomness
+ * @summary test archive lambda invoker species type in dynamic dump
+ * @bug 8280767
+ * @requires vm.cds
+ * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds /test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive
+ * @compile CDSLambdaInvoker.java
+ * @build sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar cds-test.jar CDSLambdaInvoker
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. TestLambdaInvokers
+ */
+
+public class TestLambdaInvokers extends DynamicArchiveTestBase {
+    private static final String mainClass = "CDSLambdaInvoker";
+    private static final String jarFile   = "cds-test.jar";
+    private static void doTest(String topArchiveName) throws Exception {
+        dump(topArchiveName,
+             "-Xlog:cds",
+             "-Xlog:cds+dynamic=debug",
+             "-cp",
+             jarFile,
+             mainClass)
+             .assertNormalExit(output -> {
+                 output.shouldContain("Skip regenerating for shared");
+             });
+        run(topArchiveName,
+             "-Xlog:cds",
+             "-Xlog:cds+dynamic=debug",
+             "-Xlog:class+load",
+             "-cp",
+             jarFile,
+             mainClass)
+             .assertNormalExit(output -> {
+                 // java.lang.invoke.BoundMethodHandle$Species_JL is generated from CDSLambdaInvoker
+                 output.shouldContain("java.lang.invoke.BoundMethodHandle$Species_JL source: shared objects file (top)");
+             });
+    }
+
+    static void testWithDefaultBase() throws Exception {
+        String topArchiveName = getNewArchiveName("top");
+        doTest(topArchiveName);
+    }
+
+    public static void main(String[] args) throws Exception {
+        runTest(TestLambdaInvokers::testWithDefaultBase);
+    }
+}

--- a/test/jdk/com/sun/jndi/ldap/LdapPoolTimeoutTest.java
+++ b/test/jdk/com/sun/jndi/ldap/LdapPoolTimeoutTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8277795
+ * @summary Multi-threaded client timeout tests for ldap pool
+ * @library /test/lib
+ *          lib/
+ * @run testng/othervm LdapPoolTimeoutTest
+ */
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import javax.naming.Context;
+import javax.naming.NamingException;
+import javax.naming.directory.InitialDirContext;
+import java.util.ArrayList;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.TimeUnit;
+
+import static jdk.test.lib.Utils.adjustTimeout;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+public class LdapPoolTimeoutTest {
+    /*
+     * Practical representation of an infinite timeout.
+     */
+    private static final long INFINITY_MILLIS = adjustTimeout(20_000);
+    /*
+     * The acceptable variation in timeout measurements.
+     */
+    private static final long TOLERANCE       = adjustTimeout( 3_500);
+
+    private static final long CONNECT_MILLIS  = adjustTimeout( 3_000);
+    private static final long READ_MILLIS     = adjustTimeout(10_000);
+
+    static {
+        // a series of checks to make sure this timeouts configuration is
+        // consistent and the timeouts do not overlap
+
+        assert (TOLERANCE >= 0);
+        // context creation
+        assert (2 * CONNECT_MILLIS + TOLERANCE < READ_MILLIS);
+        // context creation immediately followed by search
+        assert (2 * CONNECT_MILLIS + READ_MILLIS + TOLERANCE < INFINITY_MILLIS);
+    }
+
+    @Test
+    public void test() throws Exception {
+        List<Future<?>> futures = new ArrayList<>();
+        ExecutorService executorService = Executors.newCachedThreadPool();
+
+        Hashtable<Object, Object> env = new Hashtable<>();
+        env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
+        env.put("com.sun.jndi.ldap.read.timeout", String.valueOf(READ_MILLIS));
+        env.put("com.sun.jndi.ldap.connect.timeout", String.valueOf(CONNECT_MILLIS));
+        env.put("com.sun.jndi.ldap.connect.pool", "true");
+        env.put(Context.PROVIDER_URL, "ldap://example.com:1234");
+
+        try {
+            futures.add(executorService.submit(() -> { attemptConnect(env); return null; }));
+            futures.add(executorService.submit(() -> { attemptConnect(env); return null; }));
+            futures.add(executorService.submit(() -> { attemptConnect(env); return null; }));
+            futures.add(executorService.submit(() -> { attemptConnect(env); return null; }));
+            futures.add(executorService.submit(() -> { attemptConnect(env); return null; }));
+            futures.add(executorService.submit(() -> { attemptConnect(env); return null; }));
+            futures.add(executorService.submit(() -> { attemptConnect(env); return null; }));
+            futures.add(executorService.submit(() -> { attemptConnect(env); return null; }));
+        } finally {
+            executorService.shutdown();
+        }
+        int failedCount = 0;
+        for (var f : futures) {
+            try {
+                f.get();
+            } catch (ExecutionException e) {
+                failedCount++;
+                e.getCause().printStackTrace(System.out);
+            }
+        }
+        if (failedCount > 0)
+            throw new RuntimeException(failedCount + " (sub)tests failed");
+    }
+
+    private static void attemptConnect(Hashtable<Object, Object> env) throws Exception {
+        try {
+            LdapTimeoutTest.assertCompletion(CONNECT_MILLIS - 1000,
+                   2 * CONNECT_MILLIS + TOLERANCE,
+                   () -> new InitialDirContext(env));
+        } catch (RuntimeException e) {
+            String msg = e.getCause() == null ? e.getMessage() : e.getCause().getMessage();
+            System.err.println("MSG RTE: " + msg);
+            // assertCompletion may wrap a CommunicationException in an RTE
+            assertTrue(msg != null && msg.contains("Network is unreachable"));
+        } catch (NamingException ex) {
+            String msg = ex.getCause() == null ? ex.getMessage() : ex.getCause().getMessage();
+            System.err.println("MSG: " + msg);
+            assertTrue(msg != null &&
+                    (msg.contains("Network is unreachable")
+                        || msg.contains("Timed out waiting for lock")
+                        || msg.contains("Connect timed out")
+                        || msg.contains("Timeout exceeded while waiting for a connection")));
+        } catch (Throwable t) {
+            throw new RuntimeException(t);
+        }
+    }
+
+}
+

--- a/test/jdk/java/lang/instrument/RetransformWithMethodParametersTest.java
+++ b/test/jdk/java/lang/instrument/RetransformWithMethodParametersTest.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8240908
+ *
+ * @library /test/lib
+ * @run compile -g -parameters RetransformWithMethodParametersTest.java
+ * @run shell MakeJAR.sh retransformAgent
+ *
+ * @run main/othervm -javaagent:retransformAgent.jar RetransformWithMethodParametersTest
+ */
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.lang.instrument.ClassFileTransformer;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.ProtectionDomain;
+import java.util.Arrays;
+
+import jdk.test.lib.JDKToolLauncher;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.util.ClassTransformer;
+
+/*
+ * The test verifies Instrumentation.retransformClasses() (and JVMTI function RetransformClasses)
+ * correctly handles MethodParameter attribute:
+ * 1) classfile bytes passed to transformers (and JVMTI ClassFileLoadHook event callback) contain the attribute;
+ * 2) the attribute is updated if new version has the attribute with different values;
+ * 3) the attribute is removed if new version doesn't contain the attribute.
+ */
+
+// See ClassTransformer.transform(int) comment for @1 tag explanations.
+class MethodParametersTarget {
+    // The class contains the only method, so we don't have issue with method sorting
+    // and ClassFileReconstituter should restore the same bytes as original classbytes.
+    public void method1(
+            int intParam1, String stringParam1 // @1 commentout
+            // @1 uncomment   int intParam2, String stringParam2
+            )
+    {
+        // @1 uncomment System.out.println(stringParam2);   // change CP
+    }
+}
+
+public class RetransformWithMethodParametersTest extends ATransformerManagementTestCase {
+
+    public static void main (String[] args) throws Throwable {
+        ATestCaseScaffold test = new RetransformWithMethodParametersTest();
+        test.runTest();
+    }
+
+    private String targetClassName = "MethodParametersTarget";
+    private String classFileName = targetClassName + ".class";
+    private String sourceFileName = "RetransformWithMethodParametersTest.java";
+    private Class targetClass;
+    private byte[] originalClassBytes;
+
+    private byte[] seenClassBytes;
+    private byte[] newClassBytes;
+
+    public RetransformWithMethodParametersTest() throws Throwable {
+        super("RetransformWithMethodParametersTest");
+
+        File origClassFile = new File(System.getProperty("test.classes", "."), classFileName);
+        log("Reading test class from " + origClassFile);
+        originalClassBytes = Files.readAllBytes(origClassFile.toPath());
+        log("Read " + originalClassBytes.length + " bytes.");
+    }
+
+    private void log(Object o) {
+        System.out.println(String.valueOf(o));
+    }
+
+    private Parameter[] getTargetMethodParameters() throws ClassNotFoundException {
+        Class cls = Class.forName(targetClassName);
+        // the class contains 1 method (method1)
+        Method method = cls.getDeclaredMethods()[0];
+        Parameter[] params = method.getParameters();
+        log("Params of " + method.getName() + " method (" + params.length + "):");
+        for (int i = 0; i < params.length; i++) {
+            log("  " + i + ": " + params[i].getName()
+                    + " (" + (params[i].isNamePresent() ? "present" : "absent") + ")");
+        }
+        return params;
+    }
+
+    // Verifies MethodParameters attribute is present and contains the expected values.
+    private void verifyPresentMethodParams(String... expectedNames) throws Throwable {
+        Parameter[] params = getTargetMethodParameters();
+        assertEquals(expectedNames.length, params.length);
+        for (int i = 0; i < params.length; i++) {
+            assertTrue(params[i].isNamePresent());
+            assertEquals(expectedNames[i], params[i].getName());
+        }
+    }
+
+    // Verifies MethodParameters attribute is absent.
+    private void verifyAbsentMethodParams() throws Throwable {
+        Parameter[] params = getTargetMethodParameters();
+        for (int i = 0; i < params.length; i++) {
+            assertTrue(!params[i].isNamePresent());
+        }
+    }
+
+    // Retransforms target class using provided class bytes;
+    // Returns class bytes passed to the transformer.
+    private byte[] retransform(byte[] classBytes) throws Throwable {
+        seenClassBytes = null;
+        newClassBytes = classBytes;
+        fInst.retransformClasses(targetClass);
+        assertTrue(targetClassName + " was not seen by transform()", seenClassBytes != null);
+        return seenClassBytes;
+    }
+
+    // Prints dissassembled class bytes.
+    private void printDisassembled(String description, byte[] bytes) throws Exception {
+        log(description + " -------------------");
+
+        File f = new File(classFileName);
+        try (FileOutputStream fos = new FileOutputStream(f)) {
+            fos.write(bytes);
+        }
+        JDKToolLauncher javap = JDKToolLauncher.create("javap")
+                .addToolArg("-verbose")
+                .addToolArg("-p")       // Shows all classes and members.
+                //.addToolArg("-c")       // Prints out disassembled code
+                //.addToolArg("-s")       // Prints internal type signatures.
+                .addToolArg(f.toString());
+        ProcessBuilder pb = new ProcessBuilder(javap.getCommand());
+        OutputAnalyzer out = ProcessTools.executeProcess(pb);
+        out.shouldHaveExitValue(0);
+        try {
+            Files.delete(f.toPath());
+        } catch (Exception ex) {
+            // ignore
+        }
+        out.asLines().forEach(s -> log(s));
+        log("==========================================");
+    }
+
+    // Verifies class bytes are equal.
+    private void compareClassBytes(byte[] expected, byte[] actual) throws Exception {
+
+        int pos = Arrays.mismatch(expected, actual);
+        if (pos < 0) {
+            log("Class bytes are identical.");
+            return;
+        }
+        log("Class bytes are different.");
+        printDisassembled("expected", expected);
+        printDisassembled("expected", actual);
+        fail(targetClassName + " did not match .class file");
+    }
+
+    protected final void doRunTest() throws Throwable {
+        beVerbose();
+
+        ClassLoader loader = getClass().getClassLoader();
+        targetClass = loader.loadClass(targetClassName);
+        // sanity check
+        assertEquals(targetClassName, targetClass.getName());
+        // sanity check
+        verifyPresentMethodParams("intParam1", "stringParam1");
+
+        addTransformerToManager(fInst, new Transformer(), true);
+
+        {
+            log("Testcase 1: ensure ClassFileReconstituter restores MethodParameters attribute");
+
+            byte[] classBytes = retransform(null);
+            compareClassBytes(originalClassBytes, classBytes);
+
+            log("");
+        }
+
+        {
+            log("Testcase 2: redefine class with changed parameter names");
+
+            byte[] classBytes = Files.readAllBytes(Paths.get(
+                    ClassTransformer.fromTestSource(sourceFileName)
+                            .transform(1, targetClassName, "-g", "-parameters")));
+            retransform(classBytes);
+            // MethodParameters attribute should be updated.
+            verifyPresentMethodParams("intParam2", "stringParam2");
+
+            log("");
+        }
+
+        {
+            log("Testcase 3: redefine class with no parameter names");
+            // compile without "-parameters"
+            byte[] classBytes = Files.readAllBytes(Paths.get(
+                    ClassTransformer.fromTestSource(sourceFileName)
+                            .transform(1, targetClassName, "-g")));
+            retransform(classBytes);
+            // MethodParameters attribute should be dropped.
+            verifyAbsentMethodParams();
+
+            log("");
+        }
+    }
+
+
+    public class Transformer implements ClassFileTransformer {
+        public Transformer() {
+        }
+
+        public String toString() {
+            return Transformer.this.getClass().getName();
+        }
+
+        public byte[] transform(ClassLoader loader, String className,
+            Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) {
+
+            if (className.equals(targetClassName)) {
+                log(this + ".transform() sees '" + className
+                        + "' of " + classfileBuffer.length + " bytes.");
+                seenClassBytes = classfileBuffer;
+                if (newClassBytes != null) {
+                    log(this + ".transform() sets new classbytes for '" + className
+                            + "' of " + newClassBytes.length + " bytes.");
+                }
+                return newClassBytes;
+            }
+
+            return null;
+        }
+    }
+}

--- a/test/jdk/javax/swing/JButton/4659800/EnterKeyActivatesButton.java
+++ b/test/jdk/javax/swing/JButton/4659800/EnterKeyActivatesButton.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.event.KeyEvent;
+import java.awt.Robot;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
+
+import static java.util.stream.Collectors.toList;
+
+/*
+ * @test
+ * @key headful
+ * @requires (os.family == "windows")
+ * @bug 4659800
+ * @summary Check whether pressing <Enter> key generates
+ * ActionEvent on focused Button or not. This is applicable only for
+ * WindowsLookAndFeel and WindowsClassicLookAndFeel.
+ * @run main EnterKeyActivatesButton
+ */
+public class EnterKeyActivatesButton {
+    private static volatile boolean buttonPressed;
+    private static JFrame frame;
+
+    public static void main(String[] s) throws Exception {
+        runTest();
+    }
+
+    private static void setLookAndFeel(String lafName) {
+        try {
+            UIManager.setLookAndFeel(lafName);
+        } catch (UnsupportedLookAndFeelException ignored) {
+            System.out.println("Ignoring Unsupported L&F: " + lafName);
+        } catch (ClassNotFoundException | InstantiationException
+                | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void disposeFrame() {
+        if (frame != null) {
+            frame.dispose();
+            frame = null;
+        }
+    }
+
+    private static void createUI() {
+        frame = new JFrame();
+        JPanel panel = new JPanel();
+        JButton focusedButton = new JButton("Button1");
+        focusedButton.addActionListener(e -> buttonPressed = true);
+        panel.add(focusedButton);
+        panel.add(new JButton("Button2"));
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frame.add(panel);
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+        focusedButton.requestFocusInWindow();
+    }
+
+    public static void runTest() throws Exception {
+        Robot robot = new Robot();
+        robot.setAutoDelay(100);
+        // Consider only Windows and Windows Classic LnFs.
+        List<String> winlafs = Arrays.stream(UIManager.getInstalledLookAndFeels())
+                                     .filter(laf -> laf.getName().startsWith("Windows"))
+                                     .map(laf -> laf.getClassName())
+                                     .collect(toList());
+
+        for (String laf : winlafs) {
+            try {
+                buttonPressed = false;
+                System.out.println("Testing L&F: " + laf);
+                SwingUtilities.invokeAndWait(() -> {
+                    setLookAndFeel(laf);
+                    createUI();
+                });
+
+                robot.waitForIdle();
+                robot.keyPress(KeyEvent.VK_ENTER);
+                robot.keyRelease(KeyEvent.VK_ENTER);
+                robot.waitForIdle();
+
+                if (buttonPressed) {
+                    System.out.println("Test Passed for L&F: " + laf);
+                } else {
+                    throw new RuntimeException("Test Failed, button not pressed for L&F: " + laf);
+                }
+
+            } finally {
+                SwingUtilities.invokeAndWait(EnterKeyActivatesButton::disposeFrame);
+            }
+        }
+
+    }
+}

--- a/test/jdk/javax/swing/JRootPane/DefaultButtonTest.java
+++ b/test/jdk/javax/swing/JRootPane/DefaultButtonTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Robot;
+import java.awt.event.KeyEvent;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
+
+/*
+ * @test
+ * @key headful
+ * @bug 8280913
+ * @summary Check whether the default button is honored when <Enter> key is pressed.
+ * @run main DefaultButtonTest
+ */
+public class DefaultButtonTest {
+    private volatile boolean buttonPressed;
+    private JFrame frame;
+
+    public static void main(String[] s) throws Exception {
+        DefaultButtonTest test = new DefaultButtonTest();
+        test.runTest();
+    }
+
+    private static void setLookAndFeel(String lafName) {
+        try {
+            UIManager.setLookAndFeel(lafName);
+        } catch (UnsupportedLookAndFeelException ignored) {
+            System.out.println("Ignoring Unsupported L&F: " + lafName);
+        } catch (ClassNotFoundException | InstantiationException
+                | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void disposeFrame() {
+        if (frame != null) {
+            frame.dispose();
+            frame = null;
+        }
+    }
+
+    private void createUI() {
+        frame = new JFrame("Default Button Test");
+        JPanel panel = new JPanel();
+        panel.add(new JTextField("Text field"));
+        JButton button1 = new JButton("Default");
+        button1.addActionListener(e -> buttonPressed = true);
+        panel.add(button1);
+        panel.add(new JButton("Button2"));
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frame.add(panel);
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.getRootPane().setDefaultButton(button1);
+        frame.setVisible(true);
+    }
+
+    public void runTest() throws Exception {
+        Robot robot = new Robot();
+        robot.setAutoDelay(100);
+        for (UIManager.LookAndFeelInfo laf : UIManager.getInstalledLookAndFeels()) {
+            try {
+                buttonPressed = false;
+                String lafName = laf.getClassName();
+                System.out.println("Testing L&F: " + lafName);
+                SwingUtilities.invokeAndWait(() -> {
+                    setLookAndFeel(lafName);
+                    createUI();
+                });
+                robot.waitForIdle();
+                robot.keyPress(KeyEvent.VK_ENTER);
+                robot.keyRelease(KeyEvent.VK_ENTER);
+                robot.waitForIdle();
+
+                if (buttonPressed) {
+                    System.out.println("Test Passed for L&F: " + lafName);
+                } else {
+                    throw new RuntimeException("Test Failed, Default Button not pressed for L&F: " + lafName);
+                }
+            } finally {
+                SwingUtilities.invokeAndWait(this::disposeFrame);
+            }
+        }
+    }
+}

--- a/test/jdk/sun/security/pkcs12/KeytoolOpensslInteropTest.java
+++ b/test/jdk/sun/security/pkcs12/KeytoolOpensslInteropTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -462,7 +462,7 @@ public class KeytoolOpensslInteropTest {
                 "pkcs12", "-in", "ksnormal", "-passin", "pass:changeit",
                 "-info", "-nokeys", "-nocerts");
         output1.shouldHaveExitValue(0)
-            .shouldContain("MAC:").shouldContain("sha256").shouldContain("Iteration 10000")
+            .shouldMatch("MAC:.*sha256.*Iteration 10000")
             .shouldContain("Shrouded Keybag: PBES2, PBKDF2, AES-256-CBC,"
                     + " Iteration 10000, PRF hmacWithSHA256")
             .shouldContain("PKCS7 Encrypted data: PBES2, PBKDF2, AES-256-CBC,"
@@ -505,7 +505,7 @@ public class KeytoolOpensslInteropTest {
                 "ksnewic", "-passin", "pass:changeit", "-info", "-nokeys",
                 "-nocerts");
         output1.shouldHaveExitValue(0)
-            .shouldContain("MAC:").shouldContain("sha256").shouldContain("Iteration 5555")
+            .shouldMatch("MAC:.*sha256.*Iteration 5555")
             .shouldContain("Shrouded Keybag: PBES2, PBKDF2, AES-256-CBC,"
                     + " Iteration 7777, PRF hmacWithSHA256")
             .shouldContain("Shrouded Keybag: pbeWithSHA1And128BitRC4,"

--- a/test/lib/jdk/test/lib/util/ClassTransformer.java
+++ b/test/lib/jdk/test/lib/util/ClassTransformer.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.test.lib.util;
+
+import jdk.test.lib.compiler.CompilerUtils;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.text.MessageFormat;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+// ClassTransformer provides functionality to transform java source and compile it.
+// We cannot use InMemoryJavaCompiler as test files usually contain 2 classes (the test itself and debuggee)
+// and InMemoryJavaCompiler cannot compile them.
+public class ClassTransformer {
+
+    private final List<String> lines;
+    private String fileName;
+    private String workDir = "ver{0}";
+    private static final String LINE_SEPARATOR = System.getProperty("line.separator");
+
+    private ClassTransformer(List<String> lines) {
+        this.lines = lines;
+    }
+
+    public ClassTransformer setFileName(String fileName) {
+        this.fileName = fileName;
+        return this;
+    }
+
+    // workDir is a MessageFormat pattern, id (int) is an {0} arg of the pattern.
+    // can be relative (relatively "scratch" dir) or absolute.
+    public ClassTransformer setWorkDir(String dir) {
+        workDir = dir;
+        return this;
+    }
+
+    public static ClassTransformer fromString(String content) {
+        return new ClassTransformer(Arrays.asList(content.split("\\R")));
+    }
+
+    public static ClassTransformer fromFile(Path filePath) {
+        try {
+            return new ClassTransformer(Files.readAllLines(filePath))
+                    .setFileName(filePath.getFileName().toString());
+        } catch (IOException e) {
+            throw new RuntimeException("failed to read " + filePath, e);
+        }
+    }
+    public static ClassTransformer fromFile(String filePath) {
+        return fromFile(Paths.get(filePath));
+    }
+
+    public static ClassTransformer fromTestSource(String fileName) {
+        return fromFile(Paths.get(System.getProperty("test.src")).resolve(fileName));
+    }
+
+    // returns path to the .class file of the transformed class
+    public String transform(int id, String className, String... compilerOptions) {
+        Path subdir = Paths.get(".").resolve(MessageFormat.format(workDir, id));
+        Path transformedSrc = subdir.resolve(fileName);
+        try {
+            Files.createDirectories(subdir);
+            Files.write(transformedSrc, transform(id).getBytes());
+        } catch (IOException e) {
+            throw new RuntimeException("failed to write transformed " + transformedSrc, e);
+        }
+        try {
+            // need to add extra classpath args
+            List<String> args = new LinkedList<>(Arrays.asList(compilerOptions));
+            args.add("-cp");
+            args.add(System.getProperty("java.class.path"));
+            CompilerUtils.compile(subdir, subdir, false, args.toArray(new String[args.size()]));
+        } catch (IOException e) {
+            throw new RuntimeException("failed to compile " + transformedSrc, e);
+        }
+        return subdir.resolve(className + ".class").toString();
+    }
+
+    /*
+    * To do RedefineClasses operations, embed @1 tags in the .java
+    * file to tell this script how to modify it to produce the 2nd
+    * version of the .class file to be used in the redefine operation.
+    * Here are examples of each editing tag and what change
+    * it causes in the new file.  Note that blanks are not preserved
+    * in these editing operations.
+    *
+    * @1 uncomment
+    *  orig:   // @1 uncomment   gus = 89;
+    *  new:         gus = 89;
+    *
+    * @1 commentout
+    *  orig:   gus = 89      // @1 commentout
+    *  new: // gus = 89      // @1 commentout
+    *
+    * @1 delete
+    *  orig:  gus = 89      // @1 delete
+    *  new:   entire line deleted
+    *
+    * @1 newline
+    *  orig:  gus = 89;     // @1 newline gus++;
+    *  new:   gus = 89;     //
+    *         gus++;
+    *
+    * @1 replace
+    *  orig:  gus = 89;     // @1 replace gus = 90;
+    *  new:   gus = 90;
+    */
+    public String transform(int id) {
+        Pattern delete = Pattern.compile("@" + id + " *delete");
+        Pattern uncomment = Pattern.compile("// *@" + id + " *uncomment (.*)");
+        Pattern commentout = Pattern.compile(".* @" + id + " *commentout");
+        Pattern newline = Pattern.compile("(.*) @" + id + " *newline (.*)");
+        Pattern replace = Pattern.compile("@" + id + " *replace (.*)");
+        return lines.stream()
+                .filter(s -> !delete.matcher(s).find())     // @1 delete
+                .map(s -> {
+                    Matcher m = uncomment.matcher(s);       // @1 uncomment
+                    return m.find() ? m.group(1) : s;
+                })
+                .map(s-> {
+                    Matcher m = commentout.matcher(s);      // @1 commentout
+                    return m.find() ? "//" + s : s;
+                })
+                .map(s -> {
+                    Matcher m = newline.matcher(s);         // @1 newline
+                    return m.find() ? m.group(1) + LINE_SEPARATOR + m.group(2) : s;
+                })
+                .map(s -> {
+                    Matcher m = replace.matcher(s);         // @1 replace
+                    return m.find() ? m.group(1) : s;
+                })
+                .collect(Collectors.joining(LINE_SEPARATOR));
+    }
+
+}


### PR DESCRIPTION
@magicus Managed to find a solution that (at least seems to) resolves https://github.com/openjdk/jdk/pull/6152/commits/3c93c740e6d0d8624be6f87b5495d61b408167bd not working with MSVC. The following was built on MSYS2 with cl as the compiler without any issues:
```
openjdk 19-internal 2022-09-20
OpenJDK Runtime Environment (build 19-internal-adhoc.vertig0.jdk)
OpenJDK 64-Bit Server VM (build 19-internal-adhoc.vertig0.jdk, mixed mode)
```
I'm not sure if that may be the result of me omitting to revert the changes that commit made in `make/autoconf/spec.gmk.in`, since I wasn't too sure what the purpose of the null/unset check was (Still trying to familiarize with the build system), but I am decently confident that the initial issue has been resolved. Now for a neater way to go about doing it though...

EDIT: Looks like I mistakenly merged master into this, I'll put the actual commit here for easier access:
https://github.com/magicus/jdk/pull/2/commits/085ae29f2f01df1f06433713f5a554e7f3b375aa